### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/wumingsheng/529c32dc-feb2-4b58-ba30-26153da17d11/677bcf4a-d458-4708-b14e-9dcd803ac8f5/_apis/work/boardbadge/b8baf1bd-c65a-4314-bb3b-c89c43490058)](https://dev.azure.com/wumingsheng/529c32dc-feb2-4b58-ba30-26153da17d11/_boards/board/t/677bcf4a-d458-4708-b14e-9dcd803ac8f5/Microsoft.RequirementCategory)
 # 三剑客
 - ln -s ~/Documents/config/init.vim ~/.config/nvim/init.vim
 - ln -s ~/Documents/config/zshrc ~/.zshrc


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/wumingsheng/529c32dc-feb2-4b58-ba30-26153da17d11/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.